### PR TITLE
Feature/issues #1 チーム情報の操作に関しての機能を整えること

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -27,15 +27,19 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
-    if assigned_user == assign.team.owner
-      I18n.t('views.messages.cannot_delete_the_leader')
-    elsif Assign.where(user_id: assigned_user.id).count == 1
-      I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assign.destroy
-      set_next_team(assign, assigned_user)
-      I18n.t('views.messages.delete_member')
+    if current_user == assign.team.owner || current_user == assigned_user
+      if assigned_user == assign.team.owner
+        I18n.t('views.messages.cannot_delete_the_leader')
+      elsif Assign.where(user_id: assigned_user.id).count == 1
+        I18n.t('views.messages.cannot_delete_only_a_member')
+      elsif assign.destroy
+        set_next_team(assign, assigned_user)
+        I18n.t('views.messages.delete_member')
+      else
+        I18n.t('views.messages.cannot_delete_member_4_some_reason')
+      end
     else
-      I18n.t('views.messages.cannot_delete_member_4_some_reason')
+      'ownerかユーザー自身でないと削除できません'
     end
   end
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :team_owner?, only: %i[edit update destroy]
 
   def index
     @teams = Team.all
@@ -55,5 +56,11 @@ class TeamsController < ApplicationController
 
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+  end
+
+  def team_owner?
+    unless @team.owner == current_user
+      redirect_to @team, notice: 'owner以外編集できません！'
+    end
   end
 end


### PR DESCRIPTION
Feature/issues #1

・Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
・TeamのeditはTeamのリーダー（オーナー）のみができるようにすること

上記、実装いたしました。
レビューお願いします！